### PR TITLE
#3 add repository service controller for job posting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+////	 Mockito.mock( record 타입 ) 틀 사용하기 위해 추가
+	testImplementation 'org.mockito:mockito-inline'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/recruitment/dto/request/JobPostingAddRequest.java
+++ b/src/main/java/com/recruitment/dto/request/JobPostingAddRequest.java
@@ -1,0 +1,16 @@
+package com.recruitment.dto.request;
+
+/**
+ * 채용공고 등록, 수정 Dto
+ */
+public record JobPostingAddRequest(
+        Long companyId,
+        String jobPostingDetails,
+        String title,
+        String jobPosition,
+        Long compensation,
+        String skills
+        ) {
+}
+
+

--- a/src/main/java/com/recruitment/dto/request/JobPostingModifyRequest.java
+++ b/src/main/java/com/recruitment/dto/request/JobPostingModifyRequest.java
@@ -1,0 +1,11 @@
+package com.recruitment.dto.request;
+
+public record JobPostingModifyRequest(
+        Long jobPostingId,
+        String jobPostingDetails,
+        String title,
+        String jobPosition,
+        Long compensation,
+        String skills
+) {
+}

--- a/src/main/java/com/recruitment/dto/response/JobPostingDetailResponse.java
+++ b/src/main/java/com/recruitment/dto/response/JobPostingDetailResponse.java
@@ -1,0 +1,33 @@
+package com.recruitment.dto.response;
+
+import com.recruitment.domain.Company;
+import com.recruitment.domain.JobPosting;
+import com.recruitment.domain.JobPostingDetails;
+
+import java.util.List;
+
+public record JobPostingDetailResponse(
+        Long jobPostingId,
+        String companyName,
+        String country,
+        String city,
+        String jobPosition,
+        Long compensation,
+        String skills,
+        String details,
+        List<Long> sameCompanyJobPostingIds
+) {
+    public static JobPostingDetailResponse fromEntities(JobPosting jobPosting, JobPostingDetails jobPostingDetails, Company company, List<Long> sameCompanyJobPostingIds) {
+        return new JobPostingDetailResponse(
+                jobPosting.getId(),
+                company.getCompanyName(),
+                company.getCountry(),
+                company.getCity(),
+                jobPosting.getJobPosition(),
+                jobPosting.getCompensation(),
+                jobPosting.getSkills(),
+                jobPostingDetails.getDescription(),
+                sameCompanyJobPostingIds
+        );
+    }
+}

--- a/src/main/java/com/recruitment/dto/response/JobPostingModifyResponse.java
+++ b/src/main/java/com/recruitment/dto/response/JobPostingModifyResponse.java
@@ -1,0 +1,27 @@
+package com.recruitment.dto.response;
+
+import com.recruitment.domain.JobPosting;
+import com.recruitment.domain.JobPostingDetails;
+
+/**
+ * 채용 공고 상세 내용 Dto
+ */
+public record JobPostingModifyResponse(
+        Long jobPostingId,
+        String jobPostingDetails,
+        String title,
+        String jobPosition,
+        Long compensation,
+        String skills
+) {
+    public static JobPostingModifyResponse fromEntity(JobPosting jobPosting, JobPostingDetails jobPostingDetails1) {
+        return new JobPostingModifyResponse(
+                jobPosting.getId(),
+                jobPostingDetails1.getDescription(),
+                jobPosting.getTitle(),
+                jobPosting.getJobPosition(),
+                jobPosting.getCompensation(),
+                jobPosting.getSkills()
+        );
+    }
+}

--- a/src/main/java/com/recruitment/dto/response/JobPostingResponse.java
+++ b/src/main/java/com/recruitment/dto/response/JobPostingResponse.java
@@ -1,0 +1,36 @@
+package com.recruitment.dto.response;
+
+import com.recruitment.domain.Company;
+import com.recruitment.domain.JobPosting;
+
+import java.time.ZonedDateTime;
+
+/**
+ * 채용공고 목록 응답 Dto
+ */
+public record JobPostingResponse(
+    Long jobPostingId,
+    String companyName,
+    Long companyId,
+    String country,
+    String city,
+    String jobPosition,
+    Long compensation,
+    String skills,
+    ZonedDateTime lastUpdate
+) {
+
+    public static JobPostingResponse fromEntities(JobPosting jobPosting, Company company) {
+        return new JobPostingResponse(
+                jobPosting.getId(),
+                company.getCompanyName(),
+                company.getId(),
+                company.getCountry(),
+                company.getCity(),
+                jobPosting.getJobPosition(),
+                jobPosting.getCompensation(),
+                jobPosting.getSkills(),
+                jobPosting.getLastUpdate()
+        );
+    }
+}

--- a/src/main/java/com/recruitment/dto/response/PagingMetaData.java
+++ b/src/main/java/com/recruitment/dto/response/PagingMetaData.java
@@ -1,0 +1,10 @@
+package com.recruitment.dto.response;
+
+public record PagingMetaData(
+        int currentPage,
+        int totalPages,
+        long totalItems,
+        int itemsPerPage
+) {
+
+}

--- a/src/main/java/com/recruitment/dto/response/PagingResponse.java
+++ b/src/main/java/com/recruitment/dto/response/PagingResponse.java
@@ -1,0 +1,9 @@
+package com.recruitment.dto.response;
+
+import java.util.List;
+
+public record PagingResponse<T>(
+        List<T> data,
+        PagingMetaData metaData
+) {
+}

--- a/src/main/java/com/recruitment/repository/JobPostingRepository.java
+++ b/src/main/java/com/recruitment/repository/JobPostingRepository.java
@@ -13,7 +13,7 @@ public interface JobPostingRepository extends JpaRepository<JobPosting, Long> {
     /**
      * Company 와 Join 후에 최신 업데이트 순서로 paging
      */
-    @Query("SELECT new com.recruitment.dto.response.JobPostingResponse(j.id, c.companyName, c.country, c.city, j.jobPosition, j.compensation, j.skills, j.lastUpdate) " +
+    @Query("SELECT new com.recruitment.dto.response.JobPostingResponse(j.id, c.companyName, c.id ,c.country, c.city, j.jobPosition, j.compensation, j.skills, j.lastUpdate) " +
             "FROM JobPosting j JOIN j.company c ORDER BY j.lastUpdate DESC")
     Page<JobPostingResponse> findAllByOrderByLastUpdateDesc(Pageable pageable);
 

--- a/src/main/java/com/recruitment/service/JobPostingService.java
+++ b/src/main/java/com/recruitment/service/JobPostingService.java
@@ -1,0 +1,123 @@
+package com.recruitment.service;
+
+import com.recruitment.domain.Company;
+import com.recruitment.domain.JobPosting;
+import com.recruitment.domain.JobPostingDetails;
+import com.recruitment.dto.request.JobPostingAddRequest;
+import com.recruitment.dto.request.JobPostingModifyRequest;
+import com.recruitment.dto.response.*;
+import com.recruitment.repository.JobPostingDetailsRepository;
+import com.recruitment.repository.JobPostingRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class JobPostingService {
+    private final JobPostingRepository jobPostingRepository;
+    private final JobPostingDetailsRepository jobPostingDetailsRepository;
+    private final EntityManager entityManager;
+
+    /**
+     * 목록, 등록, 수정, 삭제, 상세페이지, 키워드 검색기능
+     */
+    // 목록
+    public PagingResponse<JobPostingResponse> findJobPosting(int pageNumber) {
+        Pageable pageable = PageRequest.of(pageNumber, 20);
+        Page<JobPostingResponse> jobPostingResponsePage = jobPostingRepository.findAllByOrderByLastUpdateDesc(pageable);
+
+        List<JobPostingResponse> content = jobPostingResponsePage.getContent();
+        int currentPage = jobPostingResponsePage.getNumber();
+        long totalElements = jobPostingResponsePage.getTotalElements();
+        int totalPages = jobPostingResponsePage.getTotalPages();
+        int itemsPerPage = jobPostingResponsePage.getSize();
+
+        // 필요한 메타 데이터만 전송
+        PagingMetaData meta = new PagingMetaData(currentPage, totalPages, totalElements, itemsPerPage);
+        PagingResponse<JobPostingResponse> response = new PagingResponse<>(content, meta);
+
+        return response;
+    }
+    
+    // 등록
+    @Transactional
+    public JobPostingResponse addJobPosting(JobPostingAddRequest jobPostingAddRequest) {
+        // 채용 공고 상세내용 등록
+        JobPostingDetails jobPostingDetails = new JobPostingDetails();
+        jobPostingDetails.setDescription(jobPostingAddRequest.jobPostingDetails());
+        JobPostingDetails saveedJobPostingDetails = jobPostingDetailsRepository.save(jobPostingDetails);
+
+        // 회사 프록시
+        Company company = entityManager.getReference(Company.class, jobPostingAddRequest.companyId());
+
+        // 채용 공고 등록
+        JobPosting jobPosting = new JobPosting();
+        jobPosting.setTitle(jobPosting.getTitle());
+        jobPosting.setJobPosition(jobPosting.getJobPosition());
+        jobPosting.setCompensation(jobPosting.getCompensation());
+        jobPosting.setJobPostingDetails(saveedJobPostingDetails);
+        jobPosting.setCompany(company);
+
+        JobPosting savedJobPosting = jobPostingRepository.save(jobPosting);
+
+        return JobPostingResponse.fromEntities(savedJobPosting, company);
+    }
+
+    // 수정 TODO: Exception
+    @Transactional
+    public JobPostingModifyResponse modifyJobPosting(JobPostingModifyRequest jobPostingModifyRequest) {
+        JobPosting jobPosting = jobPostingRepository.findById(jobPostingModifyRequest.jobPostingId())
+                .orElseThrow(
+                        () -> new IllegalArgumentException("Invalid jobPostingId: " + jobPostingModifyRequest.jobPostingId())
+                );
+        JobPostingDetails jobPostingDetails = jobPosting.getJobPostingDetails();
+        jobPostingDetails.setDescription(jobPostingModifyRequest.jobPostingDetails());
+
+        jobPosting.setTitle(jobPostingModifyRequest.title());
+        jobPosting.setJobPosition(jobPostingModifyRequest.jobPosition());
+        jobPosting.setCompensation(jobPostingModifyRequest.compensation());
+        jobPosting.setSkills(jobPostingModifyRequest.skills());
+
+        return JobPostingModifyResponse.fromEntity(jobPostingRepository.save(jobPosting), jobPostingDetails);
+    }
+
+    // 삭제
+    public String deleteJobPosting(Long jobPostingId) {
+        JobPosting jobPosting = jobPostingRepository.findById(jobPostingId)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid jobPostingId: " + jobPostingId));
+
+        jobPostingRepository.delete(jobPosting);
+
+        return "삭제 되었습니다.";
+    }
+
+    // 상세 페이지, 동일 회사 공고 id list
+    public JobPostingDetailResponse findJobPostingDetails(Long jobPostingId) {
+        // id로 채용공고 찾기
+        JobPosting jobPosting = jobPostingRepository.findById(jobPostingId).orElseThrow(
+                () -> new IllegalArgumentException("Invalid jobPostingId: " + jobPostingId)
+        );
+
+        Company company = jobPosting.getCompany();
+
+        // 찾는 채용공고와 동일한 회사가 올린 채용공고 목록을 찾음
+        List<Long> sameCompanyJobPostingIds = jobPostingRepository.findByCompanyId(company.getId()).stream().map(
+                j -> j.getId()
+        ).collect(Collectors.toList());
+
+        return JobPostingDetailResponse.fromEntities(jobPosting,jobPosting.getJobPostingDetails(), company, sameCompanyJobPostingIds);
+    }
+
+    // TODO: 키워드 검색
+    public void findSearchText() {
+
+    }
+}

--- a/src/test/java/com/recruitment/service/JobPostingServiceTest.java
+++ b/src/test/java/com/recruitment/service/JobPostingServiceTest.java
@@ -1,0 +1,245 @@
+package com.recruitment.service;
+
+import com.recruitment.domain.Company;
+import com.recruitment.domain.JobPosting;
+import com.recruitment.domain.JobPostingDetails;
+import com.recruitment.dto.request.JobPostingAddRequest;
+import com.recruitment.dto.request.JobPostingModifyRequest;
+import com.recruitment.dto.response.JobPostingDetailResponse;
+import com.recruitment.dto.response.JobPostingModifyResponse;
+import com.recruitment.dto.response.JobPostingResponse;
+import com.recruitment.dto.response.PagingResponse;
+import com.recruitment.repository.JobPostingDetailsRepository;
+import com.recruitment.repository.JobPostingRepository;
+import jakarta.persistence.EntityManager;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ExtendWith(MockitoExtension.class)
+class JobPostingServiceTest {
+
+    @Mock
+    private JobPostingRepository jobPostingRepository;
+    @Mock
+    private JobPostingDetailsRepository jobPostingDetailsRepository;
+    @Mock
+    private EntityManager entityManager;
+    @InjectMocks
+    private JobPostingService jobPostingService;
+
+    // 기본 조회
+    @Test
+    @DisplayName("findJobPosting - 성공")
+    public void givenPageNumber_whenFindList_thenSucceed() {
+        // Given
+        int pageNumber = 1;
+        Pageable pageable = PageRequest.of(pageNumber, 20);
+        Page<JobPostingResponse> mockJobPostingResponsePage = mock(Page.class);
+        List<JobPostingResponse> mockContent = List.of(mock(JobPostingResponse.class));
+
+        when(jobPostingRepository.findAllByOrderByLastUpdateDesc(pageable))
+                .thenReturn(mockJobPostingResponsePage);
+        when(mockJobPostingResponsePage.getContent()).thenReturn(mockContent);
+        when(mockJobPostingResponsePage.getNumber()).thenReturn(pageNumber);
+        when(mockJobPostingResponsePage.getTotalElements()).thenReturn(1000L);
+        when(mockJobPostingResponsePage.getTotalPages()).thenReturn(5);
+        when(mockJobPostingResponsePage.getSize()).thenReturn(20);
+
+        // When
+        PagingResponse<JobPostingResponse> response = jobPostingService.findJobPosting(pageNumber);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(mockJobPostingResponsePage.getSize()).isEqualTo(response.metaData().itemsPerPage());
+    }
+
+    // 등록 성공
+    @Test
+    @DisplayName("addJobPosting - 성공")
+    public void givenJobPostingRequest_whenAdd_thenSucceed(){
+        // Given
+        JobPostingAddRequest jobPostingAddRequest = mock(JobPostingAddRequest.class);
+        JobPostingDetails jobPostingDetails = mock(JobPostingDetails.class);
+        Company company = mock(Company.class);
+        JobPosting jobPosting = mock(JobPosting.class);
+
+        when(jobPostingDetailsRepository.save(Mockito.any(JobPostingDetails.class)))
+                .thenReturn(jobPostingDetails);
+        when(jobPostingRepository.save(Mockito.any(JobPosting.class)))
+                .thenReturn(jobPosting);
+        when(entityManager.getReference(Mockito.eq(Company.class), Mockito.anyLong()))
+                .thenReturn(company);
+
+        // When
+        JobPostingResponse response = jobPostingService.addJobPosting(jobPostingAddRequest);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(jobPosting.getId()).isEqualTo(response.jobPostingId());
+        assertThat(company.getId()).isEqualTo(response.companyId());
+
+        // Verify
+        verify(jobPostingDetailsRepository).save(Mockito.any(JobPostingDetails.class));
+        verify(jobPostingRepository).save(Mockito.any(JobPosting.class));
+        verify(entityManager).getReference(Mockito.eq(Company.class),Mockito.anyLong());
+    }
+
+    // 등록 실패
+    @Test
+    @DisplayName("addJobPosting - 실패 롤백")
+    public void givenJobPostingRequest_whenAdd_thenRollback(){
+        // Given
+        JobPostingAddRequest jobPostingAddRequest = new JobPostingAddRequest(
+                1L,
+                "test details",
+                "title",
+                "jobposition",
+                100L,
+                "python"
+        );
+
+        // When
+        // 저장 시 실패
+        Mockito.doThrow(new RuntimeException("저장 실패"))
+                .when(jobPostingDetailsRepository)
+                .save(Mockito.any(JobPostingDetails.class));
+
+        // 메세지 확인
+        try {
+            jobPostingService.addJobPosting(jobPostingAddRequest);
+        } catch (RuntimeException e) {
+            Assertions.assertThat(e.getMessage()).isEqualTo("저장 실패");
+        }
+
+        // Then
+        // 저장, jobPostingRepository 호출 없음
+        Mockito.verify(jobPostingRepository, Mockito.never())
+                .save(Mockito.any(JobPosting.class));
+        Assertions.assertThat(jobPostingRepository.findAll()).isEmpty();
+    }
+
+    // 수정
+    @Test
+    @DisplayName("modifyJobPosting - 수정")
+    public void givenJobPostingModifyRequest_whenModify_thenSucceed(){
+        // Given
+        Long mockJobPostingId = 1L;
+        String mockTitle = "new title";
+        String mockJobPosition = "new position";
+        Long mockCompensation = 10L;
+        String mockSkills = "Java/Spring";
+        String mockDescription = "new description";
+
+        JobPostingModifyRequest jobPostingModifyRequest = mock(JobPostingModifyRequest.class);
+        JobPosting jobPosting = mock(JobPosting.class);
+        JobPostingDetails jobPostingDetails = mock(JobPostingDetails.class);
+        JobPosting updatedJobPosting = mock(JobPosting.class);
+
+        when(jobPostingModifyRequest.jobPostingId()).thenReturn(mockJobPostingId);
+        when(jobPostingRepository.findById(mockJobPostingId))
+                .thenReturn(Optional.of(jobPosting));
+        when(jobPosting.getJobPostingDetails())
+                .thenReturn(jobPostingDetails);
+
+        // 새로운 값으로 변경
+        when(jobPostingModifyRequest.title())
+                .thenReturn(mockTitle);
+        when(jobPostingModifyRequest.jobPosition())
+                .thenReturn(mockJobPosition);
+        when(jobPostingModifyRequest.compensation())
+                .thenReturn(mockCompensation);
+        when(jobPostingModifyRequest.skills())
+                .thenReturn(mockSkills);
+        when(jobPostingModifyRequest.jobPostingDetails())
+                .thenReturn(mockDescription);
+        when(jobPostingRepository.save(Mockito.any(JobPosting.class)))
+                .thenReturn(updatedJobPosting);
+
+        // When
+        JobPostingModifyResponse response = jobPostingService.modifyJobPosting(jobPostingModifyRequest);
+
+        // Then
+        assertThat(response).isNotNull();
+
+        // Verify
+        verify(jobPostingDetails).setDescription(mockDescription);
+        verify(jobPosting).setTitle(mockTitle);
+        verify(jobPosting).setJobPosition(mockJobPosition);
+        verify(jobPosting).setCompensation(mockCompensation);
+        verify(jobPosting).setSkills(mockSkills);
+        verify(jobPostingRepository).save(jobPosting);
+    }
+    // 삭제
+    @Test
+    @DisplayName("deleteJobPosting - 삭제")
+    public void givenJobPostingId_whenDelete_thenSucceed(){
+        // Given
+        Long jobPostingId = 1L;
+        JobPosting jobPosting = new JobPosting();
+        jobPosting.setId(jobPostingId);
+
+        when(jobPostingRepository.findById(Mockito.eq(jobPostingId)))
+                .thenReturn(Optional.of(jobPosting));
+        // When
+        String message = jobPostingService.deleteJobPosting(jobPostingId);
+        
+        // Then
+        assertThat("삭제 되었습니다.").isEqualTo(message);
+
+        // Verify
+        verify(jobPostingRepository).delete(jobPosting);
+    }
+
+    // 상세 페이지
+    @Test
+    @DisplayName("findJobPostingDetails - 성공")
+    public void givenJobPostingId_whenFind_thenSucceed(){
+        // Given
+        Long jobPostingId = 1L;
+        JobPosting jobPosting = mock(JobPosting.class);
+        JobPostingDetails jobPostingDetails = mock(JobPostingDetails.class);
+        Company company = mock(Company.class);
+        List<JobPosting> sameCompanyJobPostings = Arrays.asList(mock(JobPosting.class), mock(JobPosting.class));
+
+        when(jobPostingRepository.findById(jobPostingId)).thenReturn(Optional.of(jobPosting));
+        when(jobPosting.getCompany()).thenReturn(company);
+        when(company.getId()).thenReturn(1L);
+        when(jobPostingRepository.findByCompanyId(company.getId())).thenReturn(sameCompanyJobPostings);
+        when(jobPosting.getJobPostingDetails()).thenReturn(jobPostingDetails);
+
+        // When
+        JobPostingDetailResponse response = jobPostingService.findJobPostingDetails(jobPostingId);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(jobPosting.getId()).isEqualTo(response.jobPostingId());
+        assertThat(company.getCompanyName()).isEqualTo(response.companyName());
+        assertThat(jobPostingDetails.getDescription()).isEqualTo(response.details());
+
+        // Verify
+        verify(jobPostingRepository).findById(jobPostingId);
+        verify(jobPostingRepository).findByCompanyId(company.getId());
+    }
+
+    // TODO: 검색 기능
+}


### PR DESCRIPTION
## job posting 을 위한 Service 클래스, 테스트 구현

1. fix: add mockito-online dependency
- mockito-inline : 테스트 코드에서 레코드 타입에 대해 Mockito.mock() 을 사용하기 위해 추가

2. refactor: refactor query for job_posting list
- job_posting 리스트를 요청시 company의 id가 있어야 채용 공고에서 상세 채용 공고 요청시 같은 회사의 채용공고 id를 응답해 줄 수 있다.

3. feat: add dto for paging
- 페이징을 위한 dto, 제네릭을 사용하여, 이력서 목록이나 지원자 목록을 구현시 재사용.
- 의미 있는 metadata 만 전달.

4. feat: add dto, classes, test for job_posting service
- dto : job_posting 등록, 수정, 상세내용을 위한 응답, 요청 dto 구현
- classes : service 클래스 구현
- test : 서비스 클래스에 대한 테스트, MockExtension 사용

TODO: 키워드 검색 메서드, 테스트 구현